### PR TITLE
feat(reader): remove `fromFilePath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ yarn add ofx-data-extractor
 ### Methods
 The `Ofx` class provides the following methods:
 
-- `async fromBuffer(data: Buffer)`: Used to read files on the node. Returns the methods
-- `async fromFilePath(path: string)`: Used to read files on the node. Returns the methods below.
+- `fromBuffer(data: Buffer)`: Used to read files on the node. Returns the methods
 - `fromBlob(data: Blob)`: Used to read files in the browser. Returns the methods below.
 - `config(options: OfxConfig)`: Used for formatting the generated json.`
 - `getHeaders(): OFXMetaData`: Returns the metadata section of the OFX file as an object.
@@ -65,8 +64,6 @@ import fs from 'fs'
 
 const file = await fs.readFile('/path/to/file')
 const ofx = await Ofx.fromBuffer(file)
-// OR
-const ofx = await Ofx.fromFilePath('/path/to/file')
 
 const ofxResponse = ofx.toJson()
 console.log(ofxResponse)

--- a/src/common/reader.ts
+++ b/src/common/reader.ts
@@ -2,18 +2,6 @@ export function bufferToString(data: Buffer) {
   return data.toString()
 }
 
-export async function fileFromPathToString(pathname: string) {
-  const fileData: string = await new Promise((resolve, reject) => {
-    import('fs').then(fs => {
-      return fs.readFile(pathname, (err, data) => {
-        if (err) reject(err)
-        else resolve(data.toString())
-      })
-    })
-  })
-  return fileData
-}
-
 export async function blobToString(blob: Blob): Promise<string> {
   const data: string = await new Promise((resolve, reject) => {
     if (typeof window !== 'undefined' && window.FileReader) {

--- a/src/implementations/reader.ts
+++ b/src/implementations/reader.ts
@@ -1,8 +1,4 @@
-import {
-  blobToString,
-  bufferToString,
-  fileFromPathToString,
-} from '../common/reader'
+import { blobToString, bufferToString } from '../common/reader'
 
 export class Reader {
   private dataRead: string = ''
@@ -23,10 +19,6 @@ export class Reader {
     return new Reader(bufferToString(data))
   }
 
-  public async fromFilePath(pathname: string): Promise<Reader> {
-    return new Reader(await fileFromPathToString(pathname))
-  }
-
   public async fromBlob(blob: Blob): Promise<Reader> {
     return new Reader(await blobToString(blob))
   }
@@ -37,10 +29,6 @@ export class Reader {
 
   public static fromBuffer(data: Buffer) {
     return new Reader(bufferToString(data))
-  }
-
-  public static async fromFilePath(pathname: string): Promise<Reader> {
-    return new Reader(await fileFromPathToString(pathname))
   }
 
   public static async fromBlob(blob: Blob): Promise<Reader> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,5 @@
 export { Ofx } from './older-implementation/main'
-export {
-  blobToString,
-  bufferToString,
-  fileFromPathToString,
-} from './common/reader'
+export { blobToString, bufferToString } from './common/reader'
 export { fixJsonProblems } from './common/parse'
 export { formatDate } from './common/date'
 export type { IExtractor } from './interfaces/extractor.interface'

--- a/src/older-implementation/main.ts
+++ b/src/older-implementation/main.ts
@@ -17,11 +17,6 @@ export class Ofx {
     return new Ofx(Reader.fromBuffer(data).getData())
   }
 
-  static async fromFilePath(pathname: string) {
-    const reader = await Reader.fromFilePath(pathname)
-    return new Ofx(reader.getData())
-  }
-
   static async fromBlob(blob: Blob): Promise<Ofx> {
     const reader = await Reader.fromBlob(blob)
     return new Ofx(reader.getData())

--- a/tests/file-reader.node.spec.ts
+++ b/tests/file-reader.node.spec.ts
@@ -1,10 +1,11 @@
+import { readFileSync } from 'fs'
 import { Ofx } from '../src/index'
 import path from 'path'
-import { fileFromPathToString } from '../src/common/reader'
 
 describe('Tests in the Node.js environment', () => {
   test.concurrent('Should read file path', async () => {
-    const ofx = await Ofx.fromFilePath(path.resolve(__dirname, 'example.ofx'))
+    const file = readFileSync(path.resolve(__dirname, 'example.ofx'))
+    const ofx = Ofx.fromBuffer(file)
     const headers = ofx.getHeaders()
     expect(headers.OFXHEADER).toBe('100')
     expect(headers.CHARSET).toBe('1252')
@@ -13,23 +14,12 @@ describe('Tests in the Node.js environment', () => {
   })
 
   test.concurrent('Should read contents from Buffer', async () => {
-    const file = await fileFromPathToString(
-      path.resolve(__dirname, 'example.ofx'),
-    )
-    const ofx = new Ofx(file)
+    const file = readFileSync(path.resolve(__dirname, 'example.ofx'))
+    const ofx = new Ofx(file.toString())
     const headers = ofx.getHeaders()
     expect(headers.OFXHEADER).toBe('100')
     expect(headers.CHARSET).toBe('1252')
     expect(headers.ENCODING).toBe('UTF-8')
     expect(headers.VERSION).toBe('102')
-  })
-
-  test.concurrent('Should throw error for invalid file path', async () => {
-    expect(() =>
-      fileFromPathToString(path.resolve(__dirname, 'exampl.ofx')),
-    ).rejects.toMatchObject({
-      code: 'ENOENT',
-      syscall: 'open',
-    })
   })
 })

--- a/tests/ofx.spec.ts
+++ b/tests/ofx.spec.ts
@@ -6,15 +6,6 @@ describe('Tests in the Node.js environment', () => {
   const file = fs.readFileSync(path.resolve(__dirname, 'example.ofx'))
   const ofx = Ofx.fromBuffer(file)
 
-  test('Should read file path', async () => {
-    const ofx = await Ofx.fromFilePath(path.resolve(__dirname, 'example.ofx'))
-    const headers = ofx.getHeaders()
-    expect(headers.OFXHEADER).toBe('100')
-    expect(headers.CHARSET).toBe('1252')
-    expect(headers.ENCODING).toBe('UTF-8')
-    expect(headers.VERSION).toBe('102')
-  })
-
   test('Deveria ler conteúdo do Buffer', async () => {
     const file = fs.readFileSync(path.resolve(__dirname, 'example.ofx'))
     const ofx = Ofx.fromBuffer(file)


### PR DESCRIPTION
The package should avoid using environment-specific functions, such as `fs` to read files from the path