### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - main
       - 'ci/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fabiopf02/ofx-data-extractor/security/code-scanning/9](https://github.com/Fabiopf02/ofx-data-extractor/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves linting, testing, and uploading coverage reports, it does not require write permissions. The minimal required permission is `contents: read`. We will add this permission at the root level of the workflow to apply it to all jobs (`lint` and `test`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
